### PR TITLE
fix: 데몬실행시 로그 콘솔출력 현상 해결

### DIFF
--- a/SERVER/Makefile
+++ b/SERVER/Makefile
@@ -36,7 +36,7 @@ OBJ_DIR_LOGIN		= obj/login
 OBJ_DIR_CHAT		= obj/chat
 
 # subdirectories
-LOG_DIR = $(SRC_DIR)/log
+COMMON_DIR = $(SRC_DIR)/COMMON
 
 DAEMON_DIR	= $(SRC_DIR_MAIN)/daemon
 MANAGER_DIR = $(SRC_DIR_MAIN)/manager
@@ -55,7 +55,7 @@ CHAT_UTIL_DIR = $(SRC_DIR_CHAT)/util
 # Source Files
 # ==================================
 SRCS_COMMON =\
-	$(LOG_DIR)/K_slog.cpp
+	$(COMMON_DIR)/K_slog.cpp
 
 SRCS_MAIN =\
 	$(DAEMON_DIR)/BaseDaemon.cpp \

--- a/SERVER/src/COMMON/K_slog.cpp
+++ b/SERVER/src/COMMON/K_slog.cpp
@@ -1,0 +1,76 @@
+#include "K_slog.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+int K_slog_init(const char* path, const char *fileName)
+{
+    slog_init(fileName, SLOG_FLAGS_ALL, 0);
+
+    slog_config_t config;
+    slog_config_get(&config);
+    config.nToFile = 1;
+    config.eDateControl = SLOG_DATE_FULL;
+	config.nKeepOpen = 0;
+	config.nToScreen = 0;	//화면(콘솔) 로그 출력 OFF
+	strncpy(config.sFilePath, path, sizeof(config.sFilePath) -1);
+    slog_config_set(&config);
+    
+	return 0;
+}
+int K_slog_close()
+{
+    slog_destroy();
+	return 0;
+}
+
+int K_slog_trace(enum e_slog lev, const char* pszFmt, ...)
+{
+	char* pBuf = NULL;
+	int nLen = 0;
+	va_list args;
+
+	// //로그레벨 0일경우 로그출력 X, TRACE는 로그레벨 0이상부터 출력
+	// if (pKcoContext->gw_nLog_level == 0 || (lev != K_SLOG_TRACE && pKcoContext->gw_nLog_level < lev))
+	// 	return KCE_APP_FAIL;
+
+	va_start(args, pszFmt);
+	nLen = vsnprintf(NULL, 0, pszFmt, args);
+	va_end(args);
+
+	if (nLen < 0)
+		return -1;
+
+	pBuf = (char*)calloc(nLen + 1, sizeof(char));
+	if (pBuf == NULL)
+		return -1;
+
+	va_start(args, pszFmt);
+	vsnprintf(pBuf, nLen + 1, pszFmt, args);
+	va_end(args);
+
+	switch (lev)
+	{
+	case K_SLOG_DEBUG:
+		slog_display(SLOG_DEBUG, 1, pBuf);
+		break;
+	/*case K_SLOG_WARN:
+		slog_display(SLOG_WARN, 1, pBuf);
+		break;*/
+	case K_SLOG_ERROR:
+		slog_display(SLOG_ERROR, 1, pBuf);
+		break;
+
+    default:
+	case K_SLOG_TRACE:
+		slog_display(SLOG_TRACE, 1, pBuf);
+		break;
+
+	}
+
+
+	free(pBuf);
+
+	return 0;
+}


### PR DESCRIPTION


<!--
    PR 제목 형식
    :sparkles: [Feature] 제목
    :hammer: [Refactoring] 제목
    :bug: [Fix] 제목
 -->

 ## 📌 개요 <!-- PR 내용에 대해 축약해서 적어주세요. -->
  - fix: 데몬실행시 로그 콘솔출력 현상 해결

 ## 💻 작업사항 <!-- PR 내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- K_slog_init 함수내에서 config.nToScreen 옵션 수정
- K_slog.cpp 파일을 COMMON 디렉토리로 이동 및 Makefile 수정 (기존 log폴더여서 ingore됬었음)
 ## 💡 이슈 번호 <!-- 관련된 이슈 번호를 적어주세요 (ex. "- close #4242") -->
  - close #12 
