### PR TITLE
:bug: fix: 플레이어 공격 시 몬스터의 체력이 변경되지 않는 문제 해결

### DIFF
--- a/SERVER/include/CHANNEL/core/CombatService.h
+++ b/SERVER/include/CHANNEL/core/CombatService.h
@@ -13,7 +13,8 @@ public:
     CombatService();
     ~CombatService();
 
-    int HandleAttack(Player* Attacker, int skill_id, std::string attack_dir);
+    int HandleAttack(Player* Attacker, int skill_id, int attack_dir);
+    int HandleBasicAttack(Player* Attacker, int attack_dir);
     int ApplyContactDamage(Player* player, Monster& monster);
     int CalculateSkillBaseDamage(const Player* attacker, const SkillDef& skillDef); 
 
@@ -23,7 +24,7 @@ public:
     int CalculateFinalDamage(Player* player, Monster& m) const;
 
 
-    std::vector<Monster*> ComputeHitMonsters(Player* attacker, const std::vector<Monster>& monsters, const SkillDef& skillDef, std::string attack_dir);
+    std::vector<Monster*> ComputeHitMonsters(Player* attacker, std::vector<Monster>& monsters, const SkillDef& skillDef, int attack_dir);
 private:
     static constexpr int kLevelRateMinPct = 30;
     static constexpr int kLevelRateMaxPct = 120;

--- a/SERVER/include/CHANNEL/core/MapInstance.h
+++ b/SERVER/include/CHANNEL/core/MapInstance.h
@@ -49,18 +49,15 @@ public:
     void HandleMove(Player* sender, Vec2 pos, float speed);
     void ResolveSkillHit(Player* Attacker, SkillDef& skillDef, std::vector<std::pair<Monster*, int>> hits);
     void SetPlayerHitResult(Player* player, int monster_instacneId, PlayerHitResult& result);
-    
     bool SpawnDropItem(Monster* monster, std::vector<DropResult> dropItems);
-
     void CheckDropItem();
     
 private:
-    void BroadcastMoveExcept(Player* sender, Vec2 pos, float speed);
-    void BroadcastMonsterHit(Player* Attacker, int SkillID, std::vector<MonsterHitResult> result);
-    void BroadcastPlayerHit(Player* Defender, PlayerHitResult result);
     void BroadcastDropSpawn(std::vector<DropSpawnInfo> spawnedInfos);
     void BroadcastRemoveItem(std::vector<int> removeItems);
-    void BroadcastMapInfo();
+    void SendMapInfo();
+    void SendMonsterSnapshot(Player* Enter_player);  
+    void SendMonsterMove(Player* player);
 
     // 몬스터와 플레이어의 접촉 시 
     void ProcessContactDamage(int64_t nowMs);

--- a/SERVER/include/CHANNEL/core/Monster.h
+++ b/SERVER/include/CHANNEL/core/Monster.h
@@ -46,15 +46,12 @@ public:
 	// 죽고난 후 시간 확인 
 	bool CheckRespawnTime(std::chrono::steady_clock::time_point now);
 	
-	
-	
 public:
 	// 몬스터 위치 설정
     void SetPos(Vec2 Pos){this->m_Pos.xPos = Pos.xPos; this->m_Pos.yPos = Pos.yPos;}
 	Vec2 GetPos(){return m_Pos;}
 
 	int GetLevel() const {return m_level;}
-
 	bool IsAlive() {return m_isAlive;}
 
 	int GetLastAttackerID() {return m_lastAttackerId;}
@@ -68,8 +65,12 @@ public:
 	std::string GetUniqueItemGroupID(){return m_unique_drop_Item_GroupId;}
 	
 	int GetInstanceId() const {return m_instanceId;}
+	int GetId() const {return m_monsterId;}
 	int GetCurrentHP() {return m_hp;}
 	int GetMaxHP() {return m_maxhp;}
+	int GetDir() {return m_dir;}
+	int GetMoveSpeed() {return m_moveSpeed;}
+	MonsterState GetState(){return m_state;}
 
 	int GetDamage(){return m_attackDamage;}
 	Collider2D GetCollider() {return m_collider;}
@@ -100,6 +101,7 @@ private:
 
 	// 같은 몬스터라도 구별할 수 있는 고유 값이 필요하기 때문에 추가
 	int m_instanceId;
+	int m_monsterId;
 	
 	// 죽었을 때 찍히는 시간
 	std::chrono::steady_clock::time_point m_deadTime;

--- a/SERVER/include/CHANNEL/core/Player.h
+++ b/SERVER/include/CHANNEL/core/Player.h
@@ -11,6 +11,7 @@
 #include "Collider.h"
 #include "SkillManager.h"
 #include "QuickSlotManager.h"
+#include "Weapon_Info.h"
 
 class ChannelSession;
 class MapInstance;
@@ -60,6 +61,7 @@ public:
     int GetMapId() {return m_map_id;}
     int GetLevel() const {return m_level;}
     int GetSkillLevel(int skill_id) const;
+    WeaponType GetWeaponType() const {return m_weaponType;}
     PlayerState GetState(){return m_CurrentState;}
 
     InventoryManager* GetInventoryManager() {return &m_inventoryManager;}
@@ -111,6 +113,7 @@ private:
     std::string m_name;
    
     RootJob m_root_job;
+    WeaponType m_weaponType = WeaponType::One_Hand;
 
     int m_level;
     int m_job;

--- a/SERVER/include/CHANNEL/packet/ItemPacketSender.h
+++ b/SERVER/include/CHANNEL/packet/ItemPacketSender.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "common.h"
+#include "Player.h"
+#include "Monster.h"
+#include "DropInfos.h"
+
+class ItemPacketSender
+{
+public:
+    static void SendSpawnItem(std::vector<DropSpawnInfo> spawnedInfos, std::unordered_map<int, Player*>& playerList);
+    static void SendRemoveItem(std::vector<int> removeItems, std::unordered_map<int, Player*>& playerList);
+private:
+};

--- a/SERVER/include/CHANNEL/packet/MonsterPacketSender.h
+++ b/SERVER/include/CHANNEL/packet/MonsterPacketSender.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "common.h"
+#include "Player.h"
+#include "Monster.h"
+
+class MonsterPacketSender
+{
+public:
+    static void SendMonsterSnapShot(Player* player, const std::vector<Monster*>& monsters);
+    static void SendMonsterMove(Player* player, const std::vector<Monster*>& monsters);
+    static void SendMonsterOnDamaged(Player* Attacker, int SkillID, std::vector<MonsterHitResult>& result, std::unordered_map<int, Player*>& playerList);
+private:
+};

--- a/SERVER/include/CHANNEL/packet/PlayerHandler.h
+++ b/SERVER/include/CHANNEL/packet/PlayerHandler.h
@@ -5,10 +5,6 @@
 #include "Player.h"
 #include "MySqlConnectionPool.h"
 
-void MovePacket(PacketContext * ctx);
-void AttackPacket(PacketContext * ctx);
-void OnDamagedPacket(PacketContext * ctx);
-void UseItemPacket(PacketContext * ctx);
 
 class PlayerHandler : public IPacketHandler
 {
@@ -19,6 +15,12 @@ public:
     //stat
     void HandleStatView(PacketContext* ctx);
     void HandleStatUp(PacketContext* ctx);
+
+    void MovePacket(PacketContext* ctx);
+    void AttackPacket(PacketContext* ctx);
+    void BasicAttackPacket(PacketContext* ctx);
+    void OnDamagedPacket(PacketContext* ctx);
+    void UseItemPacket(PacketContext* ctx);
   
 private:
     uint16_t m_type;

--- a/SERVER/include/CHANNEL/packet/PlayerPacketSender.h
+++ b/SERVER/include/CHANNEL/packet/PlayerPacketSender.h
@@ -7,6 +7,8 @@ public:
     static void SendPlayerInfo(Player* player);
     static void SendPlayerStat(Player* player);
     static void SendPlayerSkillList(Player* player);
+    static void SendPlayersMove(Player* sender, Vec2 pos, float speed, std::unordered_map<int, Player*>& playerList);
+    static void SendPlayerOnDamaged(Player* Defender, PlayerHitResult result, std::unordered_map<int, Player*>& playerList);
 private:
 
 

--- a/SERVER/include/CHANNEL/util/PlayerData.h
+++ b/SERVER/include/CHANNEL/util/PlayerData.h
@@ -49,6 +49,6 @@ struct PlayerInitData{
 // 임시로 여기에 구현 /*2026.02.07 LJH */
 // 플레이어가 스킬을 사용했을 때 Hit 당한 몬스터들을 관리하기 위한 구조체
 struct Cand {
-    Monster m;
-    float front;   // dx * facingSign
+    Monster* m;
+    float front;
 };

--- a/SERVER/include/COMMON/Skill_Info.h
+++ b/SERVER/include/COMMON/Skill_Info.h
@@ -2,13 +2,28 @@
 #include "common.h"
 #include "PlayerData.h"
 
-enum class SkillType 
+enum class AttackDir
 {
-    NONE,
-    BASIC,
-    MELEE_ARC,
-    ENUMEND
+    Left = -1,
+    Right = 1,
 };
+
+enum class SkillCategory
+{
+    BASIC_ATTACK,
+    ACTIVE,
+    PASSIVE,
+    NONE
+};
+
+enum class SkillCastType
+{
+    MELEE_ARC,
+    PROJECTILE,
+    AREA,
+    NONE
+};
+
 enum class HitShape  
 {
     NONE,
@@ -34,7 +49,8 @@ struct SkillDef
     int skill_id;
     std::string key;
 
-    SkillType type;
+    SkillCategory category;
+    SkillCastType cast_type;
 
     struct Hit
     {
@@ -80,12 +96,21 @@ struct LearnedSkillSlot
 
 namespace Skill
 {
-    inline SkillType SetSkillType(std::string skillType )
+    inline SkillCastType SetSkillCastType(std::string skillCastType )
     {
-        if(skillType == "BASIC") return SkillType::BASIC;
-        if(skillType == "MELEE_ARC") return SkillType::MELEE_ARC;
-        return SkillType::NONE;
+        if(skillCastType == "PROJECTILE") return SkillCastType::PROJECTILE;
+        if(skillCastType == "MELEE_ARC") return SkillCastType::MELEE_ARC;
+        if(skillCastType == "AREA") return SkillCastType::AREA;
+        return SkillCastType::NONE;
     };
+
+    inline SkillCategory SetSkillCategory(std::string skillCategory)
+    {
+        if(skillCategory == "BASIC_ATTACK") return SkillCategory::BASIC_ATTACK;
+        if(skillCategory == "ACTIVE") return SkillCategory::ACTIVE;
+        if(skillCategory == "PASSIVE") return SkillCategory::PASSIVE;
+        return SkillCategory::NONE;
+    }
 
     inline HitShape SetHitShape(std::string hitType)
     {

--- a/SERVER/include/COMMON/Weapon_Info.h
+++ b/SERVER/include/COMMON/Weapon_Info.h
@@ -1,0 +1,9 @@
+#include "common.h"
+
+enum class WeaponType
+{
+    NONE     = 29000,
+    One_Hand = 29001,
+    Two_Hand = 29002,
+    Bow      = 29003,
+};

--- a/SERVER/include/COMMON/packet/Packet.h
+++ b/SERVER/include/COMMON/packet/Packet.h
@@ -59,10 +59,12 @@ enum PACKET_TYPE : uint16_t {
     PKT_PLAYER_INFO         = 0x0024,
     PKT_PLAYER_STAT         = 0x0025,
     PKT_PLAYER_SKILLLIST    = 0x0026,
+    PKT_PLAYER_BASIC_ATTACK = 0x0027,
 
     // 0x0040 ~ 0x005F : 몬스터
     PKT_MONSTER_MOVE        = 0x0040,
     PKT_MONSTER_ONDAMAGED   = 0x0041,
+    PKT_MONSTER_SNAPSHOT    = 0x0042,
 
     // 0x0060 ~ 0x007F : 드롭
     PKT_DROPITEMS           = 0x0060,

--- a/SERVER/src/CHANNEL/Makefile
+++ b/SERVER/src/CHANNEL/Makefile
@@ -90,6 +90,8 @@ SRCS := \
 	packet/PlayerPacketSender.cpp\
 	packet/InventoryPacketSender.cpp\
 	packet/QuickSlotPacketSender.cpp\
+	packet/MonsterPacketSender.cpp\
+	packet/ItemPacketSender.cpp\
     \
     db/MySqlConnectionPool.cpp \
 	db/PlayerService.cpp \

--- a/SERVER/src/CHANNEL/core/ChannelSession.cpp
+++ b/SERVER/src/CHANNEL/core/ChannelSession.cpp
@@ -41,7 +41,7 @@ bool ChannelSession::OnBytes(const uint8_t* data, size_t len)
         K_slog_trace(K_SLOG_ERROR, "[%s][%d] Packet Parse failed", __FUNCTION__, __LINE__);
         return false;
     }
-    K_slog_trace(K_SLOG_DEBUG, "[%s][%d] parsed packet type=%x, payload len=%d", __FUNCTION__, __LINE__, pkt->type, (int)pkt->payload.size());
+    //K_slog_trace(K_SLOG_DEBUG, "[%s : %s : %d] parsed packet type=%x, payload len=%d", __FILE__, __FUNCTION__, __LINE__, pkt->type, (int)pkt->payload.size());
 
 
     auto handler = m_factory.Create(pkt->type);
@@ -58,7 +58,7 @@ bool ChannelSession::OnBytes(const uint8_t* data, size_t len)
         // PlayerManager 설정
         if (m_server) {
             ctx.player_manager = m_server->GetPlayerManager();
-            K_slog_trace(K_SLOG_DEBUG, "Player_Manager [%p]\n", ctx.player_manager);
+            //K_slog_trace(K_SLOG_DEBUG, "Player_Manager [%p]\n", ctx.player_manager);
             ctx.map_service = m_server->GetMapService();
             ctx.player_service = m_server->GetPlayerService();
             ctx.stat_service = m_server->GetStatService();
@@ -100,7 +100,7 @@ int ChannelSession::SendOk(int type, std::vector<std::string> payload)
     payload.insert(payload.begin(), "ok");
     std::string body = PacketParser::MakeBody(payload);
     std::string packet = PacketParser::MakePacket(type, body);
-    K_slog_trace(K_SLOG_TRACE, "[%s][%d] body[%s]", __FUNCTION__, __LINE__, body.c_str());
+    
     send(m_fd, packet.c_str(), packet.size(), 0);
     return 0;
 }

--- a/SERVER/src/CHANNEL/core/CombatService.cpp
+++ b/SERVER/src/CHANNEL/core/CombatService.cpp
@@ -15,7 +15,7 @@ CombatService::~CombatService()
 }
 
 
-int CombatService::HandleAttack(Player* Attacker, int skill_id, std::string attack_dir)
+int CombatService::HandleAttack(Player* Attacker, int skill_id, int attack_dir)
 {
     MapInstance* map = Attacker->GetCurrentMap();
 
@@ -34,7 +34,61 @@ int CombatService::HandleAttack(Player* Attacker, int skill_id, std::string atta
     Attacker->UseSkill(&*skillDef);
 
     // MapInstance에서 해당 맵에 스폰된 몬스터들의 정보를 추출
-    std::vector<Monster> monster_list = map->GetMonsterList();
+    std::vector<Monster>& monster_list = map->GetMonsterList();
+     
+    K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] monster_list size = %zu\n", __FILE__, __FUNCTION__, __LINE__, monster_list.size());
+
+
+    // ComputeHitMonsters(Player* attacker, const std::vector<Monster>& monsters, const SkillDef& skillDef, std::string attack_dir)
+    // 몬스터들 중에서 피격된 몬스터들을 가져온다.
+    std::vector<Monster*> HitMonsters = ComputeHitMonsters(Attacker, monster_list, *skillDef, attack_dir);
+
+    K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] HitMonsters size = %zu\n", __FILE__, __FUNCTION__, __LINE__, HitMonsters.size());
+
+
+    std::vector<std::pair<Monster*, int>> hitResults;
+    hitResults.reserve(HitMonsters.size());
+
+    // 플레이어 스킬 레벨 및 주스탯 / 보조스탯에 따라서 데미지를 계산
+    int skillDamage = CalculateSkillBaseDamage(Attacker, *skillDef);
+
+    for(Monster* monster : HitMonsters)
+    {
+        int finalDamage = CalculateFinalDamage(skillDamage,Attacker, *skillDef, *monster);
+        //monster->
+        hitResults.push_back({monster, finalDamage});
+    }
+    
+    map->ResolveSkillHit(Attacker, *skillDef, hitResults);
+  
+    return 1;
+
+}
+
+int CombatService::HandleBasicAttack(Player* Attacker, int attack_dir)
+{
+    MapInstance* map = Attacker->GetCurrentMap();
+
+    std::optional<SkillDef> skillDef = m_skillManager->GetSkill(static_cast<int>(Attacker->GetWeaponType()));
+    K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] 공격 시도 중.\n", __FILE__, __FUNCTION__, __LINE__);
+    if(!skillDef) 
+    {
+        
+        K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] 기본공격 데이터가 없습니다.\n", __FILE__, __FUNCTION__, __LINE__);
+        return 0;
+    }
+    //캐릭터가 공격 가능 상태인지 확인
+    if(!Attacker->CanAttack(&*skillDef))
+    {
+        K_slog_trace(K_SLOG_TRACE, "[%s : %s][%d] 플레이어가 공격 가능한 상태가 아닙니다.\n", __FILE__, __FUNCTION__, __LINE__);
+        return 0;
+    }
+
+    // 플레이어 스킬 사용
+    Attacker->UseSkill(&*skillDef);
+
+    // MapInstance에서 해당 맵에 스폰된 몬스터들의 정보를 추출
+    std::vector<Monster>& monster_list = map->GetMonsterList();
      
     // ComputeHitMonsters(Player* attacker, const std::vector<Monster>& monsters, const SkillDef& skillDef, std::string attack_dir)
     // 몬스터들 중에서 피격된 몬스터들을 가져온다.
@@ -55,67 +109,60 @@ int CombatService::HandleAttack(Player* Attacker, int skill_id, std::string atta
     map->ResolveSkillHit(Attacker, *skillDef, hitResults);
   
     return 1;
-
 }
 
-/*
-bool IsHitFrontBox2D(
-    const Vec2& attackerPos,
-    int facingSign,            // -1: Left, +1: Right (공격자 기준)
-    const Vec2& targetPos,
-    float range,               // 예: 120
-    float verticalTolerance    // 예: 60 (스킬별 튜닝)
-)
-*/
 
-
-std::vector<Monster*> CombatService::ComputeHitMonsters(Player* attacker, const std::vector<Monster>& monsters, const SkillDef& skillDef, std::string attack_dir)
+std::vector<Monster*> CombatService::ComputeHitMonsters(Player* attacker, std::vector<Monster>& monsters, const SkillDef& skillDef, int attack_dir)
 {
 
-    Vec2 attackerPos;
-    std::vector<Cand> CanHitMonsters;
-    std::vector<Monster*> HitMonsters;
+      Vec2 attackerPos = attacker->GetPos();
 
-    CanHitMonsters.reserve(monsters.size());
+    std::vector<Cand> canHitMonsters;
+    std::vector<Monster*> hitMonsters;
 
+    canHitMonsters.reserve(monsters.size());
 
-    // 공격 방향에 따라서 곱해주는 값 설정
-    int dir = attack_dir == "Left" ? -1 : 1;
-
-    attackerPos = attacker->GetPos();
-
-    for (Monster m : monsters)
+    for (Monster& m : monsters)
     {
         Vec2 mp = m.GetPos();
 
-        // 스킬 범위에 해당 몬스터가 있는지 없는 확인
-        if (!IsHitFrontBox2D(attackerPos, dir, mp, skillDef.hit.range, skillDef.hit.angle_deg))
+        if (!IsHitFrontBox2D(
+                attackerPos,
+                attack_dir,
+                mp,
+                skillDef.hit.range,
+                skillDef.hit.angle_deg))
+        {
             continue;
+        }
 
         float dx = mp.xPos - attackerPos.xPos;
-        float front = dx * (float)dir;
+        float front = dx * static_cast<float>(attack_dir);
 
-        CanHitMonsters.push_back({m, front});
+        canHitMonsters.push_back({ &m, front });
     }
-    
-    std::sort(CanHitMonsters.begin(), CanHitMonsters.end(),
+
+    std::sort(canHitMonsters.begin(), canHitMonsters.end(),
         [](const Cand& a, const Cand& b)
         {
-            // float은 오차가 있으니, front가 사실상 같은 경우는 instanceId로 묶는다
             if (a.front < b.front) return true;
             if (a.front > b.front) return false;
-            return a.m.GetInstanceId() < b.m.GetInstanceId();
+            return a.m->GetInstanceId() < b.m->GetInstanceId();
         });
 
-    int take = std::min<int>(skillDef.hit.max_targets, (int)CanHitMonsters.size());
-    HitMonsters.reserve(take);
+    int take = std::min<int>(
+        skillDef.hit.max_targets,
+        static_cast<int>(canHitMonsters.size())
+    );
 
-    for(int i =0; i<take; ++i)
+    hitMonsters.reserve(take);
+
+    for (int i = 0; i < take; ++i)
     {
-        HitMonsters.push_back(&CanHitMonsters[i].m);
+        hitMonsters.push_back(canHitMonsters[i].m);
     }
 
-    return HitMonsters;
+    return hitMonsters;
 
 }
 
@@ -135,7 +182,7 @@ int CombatService::CalculateSkillBaseDamage(const Player* attacker, const SkillD
 
     float dmg = statBase * levelRate * skillDef.damage.multiplier;
     dmg += static_cast<float>(skillDef.damage.flat_add);
-
+    K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Damaged [%f]", __FILE__, __FUNCTION__, __LINE__, dmg);
     if (dmg < 1.0f) dmg = 1.0f;
     return static_cast<int>(dmg);
 }

--- a/SERVER/src/CHANNEL/core/MapInstance.cpp
+++ b/SERVER/src/CHANNEL/core/MapInstance.cpp
@@ -5,6 +5,9 @@
 #include "timeUtility.h"
 #include <nlohmann/json.hpp>
 #include <fstream>
+#include "MonsterPacketSender.h"
+#include "PlayerPacketSender.h"
+#include "ItemPacketSender.h"
 
 
 #define MAPDELETELIMIT 5
@@ -51,7 +54,7 @@ int MapInstance::Update()
 	{
 		SpawnMonster();
 		UpdateMonster();
-		BroadcastMapInfo();
+		SendMapInfo();
 		ProcessContactDamage(NowMs());
 	}
 
@@ -59,29 +62,11 @@ int MapInstance::Update()
 }
 
 //맵내에 있는 모든사용자에게 Update시 보내주는 정보
-void MapInstance::BroadcastMapInfo()
+void MapInstance::SendMapInfo()
 {
-	std::vector<std::string> payload;	
-
-	//K_slog_trace(K_SLOG_TRACE, "[%s:%s][%d]m_monsterList[size:%d]", __FILE__, __FUNCTION__, __LINE__, m_monsterList.size());
-	for (auto& monster : m_monsterList)
-	{
-		if (monster.IsAlive())
-		{
-			payload.push_back(std::to_string(monster.GetInstanceId()));
-			payload.push_back(std::to_string(monster.GetPos().xPos));
-			payload.push_back(std::to_string(monster.GetPos().yPos));
-			payload.push_back(std::to_string(monster.GetCurrentHP()));
-			payload.push_back(std::to_string(monster.GetMaxHP()));
-		}
-	}
-	
-	
-	//K_slog_trace(K_SLOG_TRACE, "[%s:%s][%d]m_playerList[size:%d]", __FILE__, __FUNCTION__, __LINE__, m_playerList.size());
 	for(auto it = m_playerList.begin(); it != m_playerList.end(); ++it)
-	{	
-		auto session = it->second->GetSession();	
-		session->Send(PKT_MONSTER_MOVE, payload);
+	{
+		SendMonsterMove(it->second);
 	}
 }
 
@@ -90,19 +75,17 @@ int MapInstance::InitSpawnMonster()
 	int instanceId = 1;
     m_monsterList.reserve(m_monsterSpawnList.size());
 	
-	
-	//K_slog_trace(K_SLOG_TRACE, "[%s:%s][%d]gunoo22_TEST", __FILE__, __FUNCTION__, __LINE__);
     for(m_monsterSpawnListIter = m_monsterSpawnList.begin(); m_monsterSpawnListIter < m_monsterSpawnList.end(); ++m_monsterSpawnListIter)
     {
         Monster monster;
        
-		//K_slog_trace(K_SLOG_TRACE, "[%s:%s][%d]gunoo22_TEST", __FILE__, __FUNCTION__, __LINE__);
+		
 		if(!m_monsterManager->EnsureLoaded(m_monsterSpawnListIter->monsterId))
 		{
 			K_slog_trace(K_SLOG_ERROR, "[%s][%d] FAILED OPEN [%s] FILE", __FUNCTION__, __LINE__, m_monsterSpawnListIter->monsterId);
 			return -1;
 		}
-		//K_slog_trace(K_SLOG_TRACE, "[%s:%s][%d]gunoo22_TEST", __FILE__, __FUNCTION__, __LINE__);	
+			
 		
 		auto monsterTemplate = m_monsterManager->GetMonsterData(m_monsterSpawnListIter->monsterId);
 		
@@ -110,7 +93,7 @@ int MapInstance::InitSpawnMonster()
 		m_monsterSpawnListIter->instanceId = instanceId;
 		instanceId++;
 
-		//K_slog_trace(K_SLOG_TRACE, "[%s:%s][%d]gunoo22_TEST", __FILE__, __FUNCTION__, __LINE__);
+		
 		if(monsterTemplate.has_value())
 		{
 			(*monsterTemplate).mapId = m_mapID;
@@ -119,11 +102,11 @@ int MapInstance::InitSpawnMonster()
 			K_slog_trace(K_SLOG_ERROR, "[%s][%d] MonsterTemplate Get Failed Monster_Id[%d] FILE", __FUNCTION__, __LINE__, m_monsterSpawnListIter->monsterId);
 			return -1;
 		}
-		//K_slog_trace(K_SLOG_TRACE, "[%s:%s][%d]gunoo22_TEST", __FILE__, __FUNCTION__, __LINE__);
-			
+
         m_monsterList.push_back(monster);
-		//K_slog_trace(K_SLOG_TRACE, "[%s:%s][%d]gunoo22_TEST", __FILE__, __FUNCTION__, __LINE__);
+		
     }
+
 
     return 1;
 }   
@@ -176,6 +159,8 @@ void MapInstance::OnEnter(int PlayerID, Player* player)
 	m_playerCount++;
 	K_slog_trace(K_SLOG_DEBUG, "[%s:%s][%d] PlayerID(%d)", __FILE__, __FUNCTION__, __LINE__, PlayerID);
 	K_slog_trace(K_SLOG_DEBUG, "[%s:%s][%d] m_playerCount(%d)", __FILE__, __FUNCTION__, __LINE__, m_playerCount);
+	// 들어온 플레이어 한테 몬스터 정보 전달
+	SendMonsterSnapshot(player);
 }
 
 void MapInstance::OnLeave(int PlayerID)
@@ -222,33 +207,54 @@ void MapInstance::HandleMove(Player* sender, Vec2 pos, float speed)
 
 	sender->SetPos(pos);
 
-	BroadcastMoveExcept(sender, pos, speed);
+	PlayerPacketSender::SendPlayersMove(sender, pos, speed, m_playerList);
 }
 
-// 각 플레이어한테 이동 정보 전달
-void MapInstance::BroadcastMoveExcept(Player* sender, Vec2 pos, float speed)
+
+
+void MapInstance::SendMonsterSnapshot(Player* player)
 {
-	std::vector<std::string> payload;
-	payload.reserve(4);
-	K_slog_trace(K_SLOG_TRACE, "[%s][%d] playerID [%d]", __FUNCTION__, __LINE__, sender->GetId());
-	K_slog_trace(K_SLOG_TRACE, "[%s][%d] xPos [%f]", __FUNCTION__, __LINE__, pos.xPos);
-	K_slog_trace(K_SLOG_TRACE, "[%s][%d] yPos [%f]", __FUNCTION__, __LINE__, pos.yPos);
-	K_slog_trace(K_SLOG_TRACE, "[%s][%d] speed [%f]", __FUNCTION__, __LINE__, speed);
-	payload.push_back(std::to_string(sender->GetId()));
+     if (player == nullptr)
+    {
+        K_slog_trace(K_SLOG_ERROR, "[%s : %s : %d] player is nullptr", __FILE__, __FUNCTION__, __LINE__);
+        return;
+    }
 
-	payload.push_back(std::to_string(pos.xPos));
-	payload.push_back(std::to_string(pos.yPos));
-	payload.push_back(std::to_string(speed));
+    std::vector<Monster*> aliveMonsters;
+    aliveMonsters.reserve(m_monsterList.size());
 
-	for(auto it = m_playerList.begin(); it != m_playerList.end(); ++it)
-	{
-		if(it->second == sender) continue;
-		
-		auto session = it->second->GetSession();
-		
-		session->Send(PKT_PLAYER_MOVE, payload);
-	}
+    for (auto& monster : m_monsterList)
+    {
+        if (!monster.IsAlive())
+            continue;
+
+        aliveMonsters.push_back(&monster);
+    }
+
+    MonsterPacketSender::SendMonsterSnapShot(player, aliveMonsters);
 }
+
+ void MapInstance::SendMonsterMove(Player* player)
+ {
+	  if (player == nullptr)
+    {
+        K_slog_trace(K_SLOG_ERROR, "[%s : %s : %d] player is nullptr", __FILE__, __FUNCTION__, __LINE__);
+        return;
+    }
+
+    std::vector<Monster*> aliveMonsters;
+    aliveMonsters.reserve(m_monsterList.size());
+
+    for (auto& monster : m_monsterList)
+    {
+        if (!monster.IsAlive())
+            continue;
+
+        aliveMonsters.push_back(&monster);
+    }
+	MonsterPacketSender::SendMonsterMove(player, aliveMonsters);
+ }
+
 
 // 맵이 사라지는 경우 호출
 void MapInstance::RemoveMap()
@@ -263,14 +269,16 @@ void MapInstance::RemoveMap()
 	}
 }
 
-
+// 나중에 PacketSender로 옮겨야함
 void MapInstance::ResolveSkillHit(Player* Attacker, SkillDef& skillDef, std::vector<std::pair<Monster*, int>> hits)
 {
 	//skillDef는 상태이상 적용 시 필요한 정보 : 현재는 필요 없지만 후에 필요할지 몰라서 일단 매개변수로 추가해놓음
-	(void)skillDef;
 
+	K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] 공격 성공 ! 데이터 전송 준비 중.\n", __FILE__, __FUNCTION__, __LINE__);
 	std::vector<MonsterHitResult> results;
     results.reserve(hits.size());
+
+	 K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] ResolveSkillHit hits size = %zu\n", __FILE__, __FUNCTION__, __LINE__, hits.size());
 
 	for (auto& [m, dmg] : hits)
 	{
@@ -285,71 +293,10 @@ void MapInstance::ResolveSkillHit(Player* Attacker, SkillDef& skillDef, std::vec
 		}	
 		results.push_back({m->GetInstanceId(), dmg, m->GetCurrentHP(), m->GetMaxHP(), isDead});
 	}
-        
-	BroadcastMonsterHit(Attacker, skillDef.skill_id, results);
+    K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] SendMonsterOnDamaged.\n", __FILE__, __FUNCTION__, __LINE__);    
+	MonsterPacketSender::SendMonsterOnDamaged(Attacker, skillDef.skill_id, results, m_playerList);
 }
 
-void MapInstance::BroadcastMonsterHit(Player* Attacker, int SkillID, std::vector<MonsterHitResult> result)
-{
-	std::vector<std::string> payload;
-	payload.reserve(result.size());
-
-	payload.push_back(std::to_string(Attacker->GetId()));
-	payload.push_back(std::to_string(SkillID));
-
-	for (const auto& r : result)
-	{
-    	payload.push_back(std::to_string(r.monster_instance_id));
-    	payload.push_back(std::to_string(r.damage));
-    	payload.push_back(std::to_string(r.cur_hp));
-    	payload.push_back(std::to_string(r.max_hp));
-    	payload.push_back(r.dead ? "1" : "0");
-	}
-	for(auto it = m_playerList.begin(); it != m_playerList.end(); ++it)
-	{
-		//if(it->second == Attacker) continue;
-		
-		auto session = it->second->GetSession();
-		
-		session->Send(PKT_MONSTER_ONDAMAGED, payload);
-	}
-
-}
-
-void MapInstance::BroadcastPlayerHit(Player* Defender, PlayerHitResult result)
-{
-	  for (auto& [id, p] : m_playerList)
-    		{
-        	if (!p) continue;
-
-        	auto session = p->GetSession();
-        	if (!session) continue;
-
-        	std::vector<std::string> payload;
-        	payload.reserve(6);
-
-        	if (p == Defender)
-        	{
-        	    // 본인: 상세
-        	    payload.push_back(std::to_string(result.player_id));
-        	    payload.push_back(std::to_string(result.attacker_instance_id));
-        	    payload.push_back(std::to_string(result.damage));
-        	    payload.push_back(std::to_string(result.cur_hp));
-        	    payload.push_back(std::to_string(result.max_hp));
-        	    payload.push_back(std::to_string(static_cast<int>(result.state)));
-        	}
-        	else
-        	{
-        	    // 타인: 최소(HP 미공개)
-        	    payload.push_back(std::to_string(result.player_id));
-        	    payload.push_back(std::to_string(result.attacker_instance_id));
-        	    payload.push_back(std::to_string(result.damage));
-        	    payload.push_back(std::to_string(static_cast<int>(result.state)));
-        	}
-
-        	session->Send(PKT_PLAYER_ONDAMAGED, payload);
-    }	
-}
 
 void MapInstance::ProcessContactDamage(int64_t nowMs)
 {
@@ -387,7 +334,7 @@ void MapInstance::ProcessContactDamage(int64_t nowMs)
 			result.damage = dmg;
 			SetPlayerHitResult(player, monster.GetInstanceId(), result);
 
-			BroadcastPlayerHit(player, result);
+			PlayerPacketSender::SendPlayerOnDamaged(player, result, m_playerList);
 		}
    }
 
@@ -405,7 +352,6 @@ void MapInstance::SetPlayerHitResult(Player* player, int monster_instanceId, Pla
 
 bool MapInstance::SpawnDropItem(Monster* monster, std::vector<DropResult> dropItems)
 {
-	
 	for(size_t i =0; i < dropItems.size(); i++)
 	{
 		DropItems Item;
@@ -431,33 +377,10 @@ bool MapInstance::SpawnDropItem(Monster* monster, std::vector<DropResult> dropIt
 		m_spawnInfos.push_back(info);
 	}
 
-	BroadcastDropSpawn(m_spawnInfos);
+	ItemPacketSender::SendSpawnItem(m_spawnInfos, m_playerList);
 
 	return true;
 }
-
-void MapInstance::BroadcastDropSpawn(std::vector<DropSpawnInfo> spawnedInfos)
-{
-	for (auto& [id, p] : m_playerList)
-    {
-        if (!p) continue;
-        auto session = p->GetSession();
-        if (!session) continue;
-        std::vector<std::string> payload;
-		
-		for(size_t i =0; i < spawnedInfos.size(); i++)
-		{
-        	payload.push_back(std::to_string(spawnedInfos[i].dropId));
-        	payload.push_back(std::to_string(spawnedInfos[i].itemId));
-        	payload.push_back(std::to_string(static_cast<int>(spawnedInfos[i].type)));
-        	payload.push_back(std::to_string(spawnedInfos[i].count));
-        	payload.push_back(std::to_string(spawnedInfos[i].xPos));
-        	payload.push_back(std::to_string(spawnedInfos[i].yPos));
-        	session->Send(PKT_DROPITEMS, payload);
-		}
-    }	
-}
-
 
 void MapInstance::CheckDropItem()
 {
@@ -484,24 +407,8 @@ void MapInstance::CheckDropItem()
     	    ++it;
     	}
 	}
-	BroadcastRemoveItem(removeItems);
+	
+	ItemPacketSender::SendRemoveItem(removeItems, m_playerList);
 }
 
 
-void MapInstance::BroadcastRemoveItem(std::vector<int> removeItems)
-{
-	for (auto& [id, p] : m_playerList)
-    {
-        if (!p) continue;
-        auto session = p->GetSession();
-        if (!session) continue;
-        std::vector<std::string> payload;
-		
-		for(size_t i =0; i < removeItems.size(); i++)
-		{
-        	payload.push_back(std::to_string(removeItems[i]));
-
-        	session->Send(PKT_REMOVEITEMS, payload);
-		}
-    }	
-}

--- a/SERVER/src/CHANNEL/core/Monster.cpp
+++ b/SERVER/src/CHANNEL/core/Monster.cpp
@@ -5,14 +5,14 @@
 #include "K_slog.h"
 
 
-Monster::Monster() : m_lastAttacker(nullptr)
+Monster::Monster() : m_deadRequest(false),m_lastAttacker(nullptr)
 {
 
 }
 
 int Monster::Init(const MonsterTemplate &monsterTemplate, const MonsterSpawnData &monsterspawnData)
 {
-
+	m_monsterId = monsterTemplate.monsterId;
 	m_name = monsterTemplate.name;
 	m_hp = monsterTemplate.hp;
 	m_maxhp = monsterTemplate.hp;
@@ -144,6 +144,7 @@ int Monster::Dead()
 {
 	if (m_isAlive && !m_deadRequest)
 	{
+		 K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Is Dead", __FILE__, __FUNCTION__, __LINE__);
 		m_deadRequest = true;
 		m_deadTime = std::chrono::steady_clock::now();
 		m_isAlive = false;
@@ -175,9 +176,18 @@ bool Monster::OnDamaged(Player *Attacker, int damage)
 {
 	// 죽은 뒤 / 죽는 중이라면 무시
 	if (!m_isAlive || m_deadRequest)
+	{
+		K_slog_trace(K_SLOG_ERROR, "[%s: %s : %d] m_isAlive [%d]", __FILE__, __FUNCTION__, __LINE__,m_isAlive);
+		K_slog_trace(K_SLOG_ERROR, "[%s: %s : %d] m_deadRequest [%d]", __FILE__, __FUNCTION__, __LINE__,m_deadRequest);
 		return false;
+	}
+		
 	if (damage <= 0)
+	{
+		K_slog_trace(K_SLOG_ERROR, "[%s: %s : %d] damage [%d]", __FILE__, __FUNCTION__, __LINE__, damage);
 		return false;
+	}
+		
 
 	m_lastAttackerId = Attacker->GetId();
 	m_lastAttacker = Attacker;
@@ -185,7 +195,7 @@ bool Monster::OnDamaged(Player *Attacker, int damage)
 	m_state = E_Chase;
 
 	m_hp -= damage;
-
+	K_slog_trace(K_SLOG_TRACE, "[%s: %s : %d] m_hp [%d]", __FILE__, __FUNCTION__, __LINE__, m_hp);
 	if (m_hp <= 0)
 	{
 		m_hp = 0;

--- a/SERVER/src/CHANNEL/core/Player.cpp
+++ b/SERVER/src/CHANNEL/core/Player.cpp
@@ -87,57 +87,56 @@ void Player::SetInitData(const PlayerInitData playerInitData, const CharacterSta
 
 bool Player::CanAttack(SkillDef* skillDef)
 {
-    // 먼저 플레이어가 공격 가능한 상태인지 확인한다.
-    if(m_CurrentState == PlayerState::STUNNED) 
-    {   
+    if (skillDef == nullptr)
+    {
+        K_slog_trace(K_SLOG_TRACE, "[%s : %s][%d] skillDef is null\n", __FILE__, __FUNCTION__, __LINE__);
+        return false;
+    }
+
+    // 먼저 플레이어가 공격 가능한 상태인지 확인
+    if (m_CurrentState == PlayerState::STUNNED)
+    {
         K_slog_trace(K_SLOG_TRACE, "[%s : %s][%d] 플레이어가 공격 가능한 상태가 아닙니다.\n", __FILE__, __FUNCTION__, __LINE__);
         return false;
     }
-   
-    // 스킬의 키 값을 통해서 해당 플레이어의 직업과 연관있는지 확인한다.
 
-    // 플레이어의 출신과 스킬 사용 가능 출신이 동일한지 확인
-    if(m_root_job != skillDef->Requirements.root_job)
+    const bool isBasicAttack = (skillDef->category == SkillCategory::BASIC_ATTACK);
+
+    // 기본 공격이 아닌 경우에만 직업/습득 여부 검사
+    if (!isBasicAttack)
     {
-         K_slog_trace(K_SLOG_TRACE, "[%s : %s][%d] 플레이어가 사용 가능한 스킬이 아닙니다.\n", __FILE__, __FUNCTION__, __LINE__);
-        return false;
+        if (m_root_job != skillDef->Requirements.root_job)
+        {
+            K_slog_trace(K_SLOG_TRACE, "[%s : %s][%d] 플레이어가 사용 가능한 스킬이 아닙니다.\n", __FILE__, __FUNCTION__, __LINE__);
+            return false;
+        }
+
+        auto skillit = m_learnedSkills.find(skillDef->skill_id);
+        if (skillit == m_learnedSkills.end())
+        {
+            K_slog_trace(K_SLOG_TRACE, "[%s : %s][%d] 플레이어가 배우지 않은 스킬입니다.\n", __FILE__, __FUNCTION__, __LINE__);
+            return false;
+        }
     }
 
-    // 플레이어가 해당 스킬을 배웠는지 확인한다.
-    auto skillit = m_learnedSkills.find(skillDef->skill_id);
-    
-    if(skillit == m_learnedSkills.end())
-    {
-        K_slog_trace(K_SLOG_TRACE, "[%s : %s][%d] 플레이어가 배우지 않은 스킬입니다.\n", __FILE__, __FUNCTION__, __LINE__);
-        return false;
-    }
-
-    // 플레이어의 마나가 충분한지 확인한다.
-    if(m_stat.GetCurMp() < skillDef->mp_cost)
+    // 마나 검사
+    if (m_stat.GetCurMp() < skillDef->mp_cost)
     {
         K_slog_trace(K_SLOG_TRACE, "[%s : %s][%d] 마나가 부족합니다.\n", __FILE__, __FUNCTION__, __LINE__);
         return false;
     }
 
-    // 쿨타임 여부를 확인한다.
+    // 쿨타임 검사
+    const int64_t now = NowMs();
+
     auto coolit = skillCooldownEndMs.find(skillDef->skill_id);
-
-    if(coolit == skillCooldownEndMs.end())
-        return true;
-
-
-    // 임시로 500으로 설정 나중에 변경 필요
-    int64_t now = NowMs();
-    if(now <= coolit->second)
+    if (coolit != skillCooldownEndMs.end() && now <= coolit->second)
     {
         K_slog_trace(K_SLOG_TRACE, "[%s : %s][%d] 아직 쿨타임입니다.\n", __FILE__, __FUNCTION__, __LINE__);
         return false;
     }
 
-    
-
     return true;
-
 
 }
 

--- a/SERVER/src/CHANNEL/core/SkillManager.cpp
+++ b/SERVER/src/CHANNEL/core/SkillManager.cpp
@@ -119,7 +119,8 @@ void SkillManager::LoadSkill(nlohmann::json& j, SkillDef& skillDef)
     skillDef.skill_id = j.at("skill_id").get<int>();
 	skillDef.key = j.at("key").get<std::string>();
 
-    skillDef.type = Skill::SetSkillType(j.at("type").get<std::string>());
+    skillDef.category = Skill::SetSkillCategory(j.at("category").get<std::string>());
+    skillDef.cast_type = Skill::SetSkillCastType(j.at("cast_type").get<std::string>());
   
     skillDef.cooldown_ms = j.at("cooldown_ms").get<int>();
     skillDef.mp_cost = j.at("mp_cost").get<int>();

--- a/SERVER/src/CHANNEL/data/Maps/100000000.json
+++ b/SERVER/src/CHANNEL/data/Maps/100000000.json
@@ -3,8 +3,8 @@
   "name": "Henesys",
   "respawnDelay" : 30, 
   "monsters": [
-    { "monsterId": 100100, "xPos": -300.0, "yPos": 0.0, "group": 1 },
-    { "monsterId": 100101, "xPos":  250.0, "yPos": 0.0, "group": 2 }
+    { "monsterId": 100100, "xPos":  -300.0, "yPos": -85.0, "group": 1 },
+    { "monsterId": 100101, "xPos":  -250.0, "yPos": -60.0, "group": 2 }
   ]
 }
 

--- a/SERVER/src/CHANNEL/data/Monsters/100100.json
+++ b/SERVER/src/CHANNEL/data/Monsters/100100.json
@@ -1,6 +1,6 @@
 {
     "monster_id"    : 100100,
-    "name"          : "Slime",
+    "name"          : "Green Slime",
     "hp"            : 100,
     "attackDamage"  : 20,
     "level"         : 10,
@@ -8,7 +8,7 @@
     "moveSpeed"     : 10,
 
     "common_drop_group_id": "FIELD_COMMON_LV1_20",
-    "unique_drop_group_id": "UNIQUE_SLIME",
+    "unique_drop_group_id": "UNIQUE_GREEN_SLIME",
 
     "collider" :[{
         "type"      :   "Rect2D",

--- a/SERVER/src/CHANNEL/data/Monsters/100101.json
+++ b/SERVER/src/CHANNEL/data/Monsters/100101.json
@@ -1,11 +1,11 @@
 {
-    "monster_id" : 100101,
-    "name" : "Green_Snail",
-    "hp" : 100,
-    "attackDamage" : 2,
-    "level" : 10,
-    "exp" : 5,
-    "moveSpeed" : 10,
+    "monster_id"    : 100101,
+    "name"          : "Bule_Snail",
+    "hp"            : 100,
+    "attackDamage"  : 2,
+    "level"         : 10,
+    "exp"           : 5,
+    "moveSpeed"     : 10,
 
     "common_drop_group_id": "FIELD_COMMON_LV1_20",
     "unique_drop_group_id": "UNIQUE_GRREN_SLIME",

--- a/SERVER/src/CHANNEL/data/Skills/Archer/21001.json
+++ b/SERVER/src/CHANNEL/data/Skills/Archer/21001.json
@@ -1,7 +1,8 @@
 {
   "skill_id": 21001,
   "key": "Archer.Shot_01",
-  "type": "MELEE_ARC",
+  "category": "PROJECTILE",
+  "cast_type": "MELEE_ARC",
 
   "cooldown_ms": 500,
   "mp_cost": 10,

--- a/SERVER/src/CHANNEL/data/Skills/Common/29001.json
+++ b/SERVER/src/CHANNEL/data/Skills/Common/29001.json
@@ -1,0 +1,27 @@
+{
+  "skill_id": 29001,
+  "key": "common.basic_attack.onehand_sword",
+  "category": "BASIC_ATTACK",
+  "cast_type": "MELEE_ARC",
+
+  "cooldown_ms": 500,
+  "mp_cost": 0,
+
+  "requirements": [{"root_job": 0,"min_tier": 0,"min_skill_level": 0}],
+
+  "hit": [{ "shape": "ARC", "range": 80.0, "angle_deg": 45.0, "max_targets": 1, "hit_count": 1 }],
+  "damage": [{ "multiplier": 1.0, "flat_add": 0 }],
+
+  "effects": [{ "type": "", "force": 0 }],
+
+  "client": { "anim": "ANIM_BASIC_ATTACK", "vfx": "", "sfx": "" },
+
+
+  "__comments": [
+    "20000~20999: 전사 계열",
+    "21000~21999: 궁수 계열",
+    "22000~22999: 마법사 계열",
+    "23000~23999: 도적 계열",
+    "29000~29999: common(공용)"
+  ]
+}

--- a/SERVER/src/CHANNEL/data/Skills/Knight/20001.json
+++ b/SERVER/src/CHANNEL/data/Skills/Knight/20001.json
@@ -1,7 +1,8 @@
 {
   "skill_id": 20001,
   "key": "knight.slash_01",
-  "type": "MELEE_ARC",
+  "category": "ACTIVE",
+  "cast_type": "MELEE_ARC",
 
   "cooldown_ms": 500,
   "mp_cost": 10,

--- a/SERVER/src/CHANNEL/packet/AttackPacket.cpp
+++ b/SERVER/src/CHANNEL/packet/AttackPacket.cpp
@@ -1,3 +1,4 @@
+#include "PlayerHandler.h"
 #include "common.h"
 #include "PacketParser.h"
 #include "ChannelSession.h"
@@ -10,7 +11,7 @@
 
 // 플레이어가 공격을 했을 때 클라이언트에서 피격 여부를 판정하고 누가 피격당했는지 어떤 스킬 및 공격을 수행했는지에 대해서 정보를 전달하는 것이 아니라
 // 플레이어가 공격을 했다라는 정보만을 가지고 서버에서 피격 판정 여부와 공격 가능 여부를 판단해서 같은 맵의 플레이어들한테 정보 전달
-void AttackPacket(PacketContext * ctx)
+void PlayerHandler::AttackPacket(PacketContext * ctx)
 {   
     CombatService *combat_service = nullptr;
     ChannelSession *session = nullptr;
@@ -20,11 +21,12 @@ void AttackPacket(PacketContext * ctx)
     int rc = EXIT_SUCCESS;
 
     std::string skill_id_str;
-    std::string attack_dir;
+    std::string attack_dir_str;
     std::string errMsg;
 
     int skill_id = 0;
-     
+    int attack_dir = 0;
+
     if(ctx == nullptr)
     {
         K_slog_trace(K_SLOG_ERROR, "[%s : %s][%d] ctx is nullptr\n", __FILE__, __FUNCTION__, __LINE__);
@@ -79,7 +81,7 @@ void AttackPacket(PacketContext * ctx)
         ctx->payload,
         ctx->payload_len,
         offset,
-        attack_dir,
+        attack_dir_str,
         errMsg
     ))
     {
@@ -95,6 +97,12 @@ void AttackPacket(PacketContext * ctx)
         goto err;
     }
 
+    if(!utility::StringToInt(attack_dir_str, attack_dir)) 
+    {
+        rc = EXIT_FAILURE;
+        K_slog_trace(K_SLOG_ERROR, "[%s : %s][%d] StringToInt fail", __FILE__, __FUNCTION__, __LINE__);
+        goto err;
+    }
     combat_service->HandleAttack(player, skill_id, attack_dir);
 
 err:
@@ -105,6 +113,91 @@ err:
         session->SendOk(PKT_PLAYER_ATTACK);
     }
 
+}
+
+void PlayerHandler::BasicAttackPacket(PacketContext * ctx)
+{
+    CombatService *combat_service = nullptr;
+    ChannelSession *session = nullptr;
+    Player *player = nullptr;
+
+    size_t offset = 0;
+    int rc = EXIT_SUCCESS;
+
+    std::string attack_dir_str;
+    std::string errMsg;
+
+    int attack_dir = 0;
+    
+     K_slog_trace(K_SLOG_DEBUG, "[%s : %s : %d] BasicAttackPacket Start\n", __FILE__, __FUNCTION__, __LINE__);
+
+    if(ctx == nullptr)
+    {
+        K_slog_trace(K_SLOG_ERROR, "[%s : %s][%d] ctx is nullptr\n", __FILE__, __FUNCTION__, __LINE__);
+        rc = EXIT_FAILURE;
+        errMsg = "[" + std::to_string(rc) + "]ctx is nullptr";
+        goto err;
+    }
+
+    session = ctx->channel_session;
+    if(session == nullptr)
+    {
+     K_slog_trace(K_SLOG_ERROR, "[%s : %s][%d] session is nullptr\n", __FILE__, __FUNCTION__, __LINE__);
+        rc = EXIT_FAILURE;
+        errMsg = "[" + std::to_string(rc) + "]session is nullptr";
+        goto err;
+    }
+
+    player = session->GetPlayer();
+    if(player == nullptr)
+    {
+     K_slog_trace(K_SLOG_ERROR, "[%s : %s][%d] player is nullptr\n", __FILE__, __FUNCTION__, __LINE__);
+        rc = EXIT_FAILURE;
+        errMsg = "[" + std::to_string(rc) + "]player is nullptr";
+        goto err;
+    }
+
+    combat_service = ctx->combat_service;
+    if(combat_service == nullptr)
+    {
+     K_slog_trace(K_SLOG_ERROR, "[%s : %s][%d] combat_service is nullptr\n", __FILE__, __FUNCTION__, __LINE__);
+        rc = EXIT_FAILURE;
+        errMsg = "[" + std::to_string(rc) + "]combat_service is nullptr";
+        goto err;
+    }
+
+     // 공격 방향을 추출
+     if(!PacketParser::ParseLengthPrefixedString(
+        ctx->payload,
+        ctx->payload_len,
+        offset,
+        attack_dir_str,
+        errMsg
+    ))
+    {
+        rc = EXIT_FAILURE;
+        K_slog_trace(K_SLOG_ERROR, "[%s : %s][%d] ParseLengthPrefixedString fail", __FILE__, __FUNCTION__, __LINE__);
+        goto err;
+    }
+
+    if(!utility::StringToInt(attack_dir_str, attack_dir))
+    {
+        rc = EXIT_FAILURE;
+        K_slog_trace(K_SLOG_ERROR, "[%s : %s : %d] attack_dir String to Int Error\n", __FILE__, __FUNCTION__, __LINE__);
+        goto err;
+    }
+
+    K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] HandleBasicAttack \n", __FILE__, __FUNCTION__, __LINE__);
+
+    combat_service->HandleBasicAttack(player, attack_dir);
+
+err:
+    if (rc != EXIT_SUCCESS) { 
+        session->SendNok(PKT_PLAYER_BASIC_ATTACK, errMsg);
+    } else {
+        K_slog_trace(K_SLOG_TRACE, "[%s : %s][%d] Player Attack End", __FILE__, __FUNCTION__, __LINE__);
+        session->SendOk(PKT_PLAYER_BASIC_ATTACK);
+    }
 }
 
 

--- a/SERVER/src/CHANNEL/packet/ChannelPacketFactory.cpp
+++ b/SERVER/src/CHANNEL/packet/ChannelPacketFactory.cpp
@@ -6,7 +6,7 @@
 #include "K_slog.h"
 std::unique_ptr<IPacketHandler> ChannelPacketFactory::Create(uint16_t type)
 {
-    K_slog_trace(K_SLOG_DEBUG, "[%d][%s]type=%d", __LINE__, __FUNCTION__, type);
+    //K_slog_trace(K_SLOG_DEBUG, "[%s : %s : %d] type=%d",  __FILE__, __FUNCTION__, __LINE__, type);
     switch(type)
     {
         case PKT_INIT_CHANNEL:
@@ -18,6 +18,7 @@ std::unique_ptr<IPacketHandler> ChannelPacketFactory::Create(uint16_t type)
             break;
         case PKT_PLAYER_MOVE:
         case PKT_PLAYER_ATTACK:
+        case PKT_PLAYER_BASIC_ATTACK:
         case PKT_PLAYER_ONDAMAGED:
         case PKT_PLAYER_USE_ITEM:
         case PKT_STAT_VIEW:

--- a/SERVER/src/CHANNEL/packet/ItemPacketSender.cpp
+++ b/SERVER/src/CHANNEL/packet/ItemPacketSender.cpp
@@ -1,0 +1,43 @@
+#include "ItemPacketSender.h"  
+#include "ChannelSession.h"
+
+void ItemPacketSender::SendSpawnItem(std::vector<DropSpawnInfo> spawnedInfos, std::unordered_map<int, Player*>& playerList)
+{
+    for (auto& [id, p] : playerList)
+    {
+        if (!p) continue;
+        auto session = p->GetSession();
+        if (!session) continue;
+        std::vector<std::string> payload;
+		
+		for(size_t i =0; i < spawnedInfos.size(); i++)
+		{
+        	payload.push_back(std::to_string(spawnedInfos[i].dropId));
+        	payload.push_back(std::to_string(spawnedInfos[i].itemId));
+        	payload.push_back(std::to_string(static_cast<int>(spawnedInfos[i].type)));
+        	payload.push_back(std::to_string(spawnedInfos[i].count));
+        	payload.push_back(std::to_string(spawnedInfos[i].xPos));
+        	payload.push_back(std::to_string(spawnedInfos[i].yPos));
+        	session->Send(PKT_DROPITEMS, payload);
+		}
+    }	
+}
+
+
+void ItemPacketSender::SendRemoveItem(std::vector<int> removeItems, std::unordered_map<int, Player*>& playerList)
+{
+    for (auto& [id, p] : playerList)
+    {
+        if (!p) continue;
+        auto session = p->GetSession();
+        if (!session) continue;
+        std::vector<std::string> payload;
+		
+		for(size_t i =0; i < removeItems.size(); i++)
+		{
+        	payload.push_back(std::to_string(removeItems[i]));
+
+        	session->Send(PKT_REMOVEITEMS, payload);
+		}
+    }	
+}

--- a/SERVER/src/CHANNEL/packet/MonsterPacketSender.cpp
+++ b/SERVER/src/CHANNEL/packet/MonsterPacketSender.cpp
@@ -1,0 +1,122 @@
+#include "MonsterPacketSender.h"
+#include "ChannelSession.h"
+
+
+void MonsterPacketSender::SendMonsterSnapShot(Player* player, const std::vector<Monster*>& monsters)
+{
+    if (player == nullptr)
+        return;
+
+    auto session = player->GetSession();
+    if (session == nullptr)
+        return;
+
+    std::vector<std::string> payload;
+    payload.reserve(1 + monsters.size() * 8);
+
+    payload.push_back(std::to_string(monsters.size()));
+
+    for (auto* monster : monsters)
+    {
+        if (monster == nullptr)
+            continue;
+
+        payload.push_back(std::to_string(monster->GetId()));          // monsterTemplateId
+        payload.push_back(std::to_string(monster->GetInstanceId()));  // monsterObjectId
+        payload.push_back(std::to_string(monster->GetPos().xPos));
+        payload.push_back(std::to_string(monster->GetPos().yPos));
+        payload.push_back(std::to_string(monster->GetDir()));
+        payload.push_back(std::to_string(monster->GetMoveSpeed()));
+        payload.push_back(std::to_string(monster->GetCurrentHP()));
+        payload.push_back(std::to_string(monster->GetMaxHP()));
+        payload.push_back(std::to_string(static_cast<int>(monster->GetState())));
+// 테스트용 로그
+        //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] MonsterId [%d]", __FILE__, __FUNCTION__, __LINE__, monster->GetId());
+        //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster InstanceId [%d]", __FILE__, __FUNCTION__, __LINE__, monster->GetInstanceId());
+        //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster xPos [%f]", __FILE__, __FUNCTION__, __LINE__, monster->GetPos().xPos);
+        //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster yPos [%f]", __FILE__, __FUNCTION__, __LINE__, monster->GetPos().yPos);
+        //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster Dir [%d]", __FILE__, __FUNCTION__, __LINE__, monster->GetDir());
+        //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster CurrentHp", __FILE__, __FUNCTION__, __LINE__, monster->GetCurrentHP());
+        //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster State", __FILE__, __FUNCTION__, __LINE__, static_cast<int>(monster->GetState()));
+    }
+
+    K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster SnapShot Data Send", __FILE__, __FUNCTION__, __LINE__);
+    session->Send(PKT_MONSTER_SNAPSHOT, payload);
+}
+
+void MonsterPacketSender::SendMonsterMove(Player* player, const std::vector<Monster*>& monsters)
+{
+     if (player == nullptr)
+        return;
+
+    auto session = player->GetSession();
+    if (session == nullptr)
+        return;
+
+    std::vector<std::string> payload;
+    payload.reserve(1 + monsters.size() * 8);
+
+    payload.push_back(std::to_string(monsters.size()));
+
+    for (auto* monster : monsters)
+    {
+        if (monster == nullptr)
+            continue;
+
+        payload.push_back(std::to_string(monster->GetInstanceId()));          // monster instanceid
+        payload.push_back(std::to_string(static_cast<int>(monster->GetState())));
+        payload.push_back(std::to_string(monster->GetDir()));
+        payload.push_back(std::to_string(monster->GetPos().xPos));
+        payload.push_back(std::to_string(monster->GetPos().yPos));
+        payload.push_back(std::to_string(monster->GetCurrentHP()));
+        payload.push_back(std::to_string(monster->GetMaxHP()));
+// 테스트용 로그
+        //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster InstanceId [%d]", __FILE__, __FUNCTION__, __LINE__, monster->GetInstanceId());
+        //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster xPos [%f]", __FILE__, __FUNCTION__, __LINE__, monster->GetPos().xPos);
+        //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster yPos [%f]", __FILE__, __FUNCTION__, __LINE__, monster->GetPos().yPos);
+        //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster Dir [%d]", __FILE__, __FUNCTION__, __LINE__, monster->GetDir());
+        //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster CurrentHp [%d]", __FILE__, __FUNCTION__, __LINE__, monster->GetCurrentHP());
+        //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster State [%d]", __FILE__, __FUNCTION__, __LINE__, static_cast<int>(monster->GetState()));
+    }
+
+    //K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] Monster Move Data Send", __FILE__, __FUNCTION__, __LINE__);
+    session->Send(PKT_MONSTER_MOVE, payload);
+}
+
+
+void MonsterPacketSender::SendMonsterOnDamaged(Player* Attacker, int SkillID, std::vector<MonsterHitResult>& result, std::unordered_map<int, Player*>& playerList)
+{
+    std::vector<std::string> payload;
+	payload.reserve(3 + result.size() * 5);
+
+	payload.push_back(std::to_string(result.size()));
+	payload.push_back(std::to_string(Attacker->GetId()));
+	payload.push_back(std::to_string(SkillID));
+	for (const auto& r : result)
+	{
+    	payload.push_back(std::to_string(r.monster_instance_id));
+    	payload.push_back(std::to_string(r.damage));
+    	payload.push_back(std::to_string(r.cur_hp));
+    	payload.push_back(std::to_string(r.max_hp));
+    	payload.push_back(r.dead ? "1" : "0");
+
+            
+        K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] damage [%d]", __FILE__, __FUNCTION__, __LINE__, r.damage);
+        K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] cur_hp [%d]", __FILE__, __FUNCTION__, __LINE__, r.cur_hp);
+        K_slog_trace(K_SLOG_TRACE, "[%s : %s : %d] max_hp [%d]", __FILE__, __FUNCTION__, __LINE__, r.max_hp);
+	}
+
+    
+	for(auto it = playerList.begin(); it != playerList.end(); ++it)
+	{
+		//if(it->second == Attacker) continue;
+		
+		auto session = it->second->GetSession();
+        if (session == nullptr)
+            continue;
+		
+		session->Send(PKT_MONSTER_ONDAMAGED, payload);
+	}
+}
+
+

--- a/SERVER/src/CHANNEL/packet/MovePacket.cpp
+++ b/SERVER/src/CHANNEL/packet/MovePacket.cpp
@@ -1,3 +1,4 @@
+#include "PlayerHandler.h"
 #include "common.h"
 #include "PacketParser.h"
 #include "ChannelSession.h"
@@ -6,7 +7,7 @@
 #include "utility.h"
 
 
-void MovePacket(PacketContext * ctx)
+void PlayerHandler::MovePacket(PacketContext * ctx)
 {
     ChannelSession *session = nullptr;
     Player* player = nullptr;
@@ -123,7 +124,6 @@ err:
     if (rc != EXIT_SUCCESS) {
         session->SendNok(PKT_ENTER_MAP, errMsg);
     } else {
-        K_slog_trace(K_SLOG_TRACE, "[%s : %s][%d] MAP HANDLER END", __FILE__, __FUNCTION__, __LINE__);
         session->SendOk(PKT_ENTER_MAP);
     }
 }

--- a/SERVER/src/CHANNEL/packet/OnDamagedPacket.cpp
+++ b/SERVER/src/CHANNEL/packet/OnDamagedPacket.cpp
@@ -1,3 +1,4 @@
+#include "PlayerHandler.h"
 #include "common.h"
 #include "PacketParser.h"
 #include "ChannelSession.h"
@@ -20,7 +21,7 @@
 
 */
 
-void OnDamagedPacket(PacketContext * ctx)
+void PlayerHandler::OnDamagedPacket(PacketContext * ctx)
 {
      (void)ctx;
      

--- a/SERVER/src/CHANNEL/packet/PlayerHandler.cpp
+++ b/SERVER/src/CHANNEL/packet/PlayerHandler.cpp
@@ -28,19 +28,28 @@ void PlayerHandler::Execute(PacketContext * ctx)
           case PKT_PLAYER_ATTACK:
                AttackPacket(ctx);
                break;
+          case PKT_PLAYER_BASIC_ATTACK:
+               K_slog_trace(K_SLOG_ERROR, "[%s : %s : %d] PKT_PLAYER_BASIC_ATTACK START\n", __FILE__, __FUNCTION__, __LINE__);
+               BasicAttackPacket(ctx);
+               break;
           case PKT_PLAYER_ONDAMAGED:
+               K_slog_trace(K_SLOG_ERROR, "[%s : %s : %d] PKT_PLAYER_ONDAMAGED START\n", __FILE__, __FUNCTION__, __LINE__);
                OnDamagedPacket(ctx);
                break;
           case PKT_PLAYER_USE_ITEM:
+               K_slog_trace(K_SLOG_ERROR, "[%s : %s : %d] PKT_PLAYER_USE_ITEM START\n", __FILE__, __FUNCTION__, __LINE__);
                UseItemPacket(ctx);
                break;
           case PKT_STAT_VIEW:
-                HandleStatView(ctx);
+               K_slog_trace(K_SLOG_ERROR, "[%s : %s : %d] PKT_STAT_VIEW START\n", __FILE__, __FUNCTION__, __LINE__);
+               HandleStatView(ctx);
                 break;
           case PKT_STAT_UP:
-                HandleStatUp(ctx);
+               K_slog_trace(K_SLOG_ERROR, "[%s : %s : %d] PKT_STAT_UP START\n", __FILE__, __FUNCTION__, __LINE__);
+               HandleStatUp(ctx);
                 break;
           default :
+               K_slog_trace(K_SLOG_ERROR, "[%s : %s : %d] default START\n", __FILE__, __FUNCTION__, __LINE__);
                break;
      }
     

--- a/SERVER/src/CHANNEL/packet/PlayerPacketSender.cpp
+++ b/SERVER/src/CHANNEL/packet/PlayerPacketSender.cpp
@@ -88,3 +88,59 @@ void PlayerPacketSender::SendPlayerSkillList(Player* player)
 
     K_slog_trace(K_SLOG_TRACE, "[%s][%d] SendPlayerSkillList Send Success.", __FUNCTION__, __LINE__);
 }
+
+
+void PlayerPacketSender::SendPlayersMove(Player* sender, Vec2 pos, float speed, std::unordered_map<int, Player*>& playerList)
+{
+    std::vector<std::string> payload;
+	payload.reserve(4);
+	payload.push_back(std::to_string(sender->GetId()));
+
+	payload.push_back(std::to_string(pos.xPos));
+	payload.push_back(std::to_string(pos.yPos));
+	payload.push_back(std::to_string(speed));
+
+	for(auto it = playerList.begin(); it != playerList.end(); ++it)
+	{
+		if(it->second == sender) continue;
+		
+		auto session = it->second->GetSession();
+		
+		session->Send(PKT_PLAYER_MOVE, payload);
+	}
+}
+
+void PlayerPacketSender::SendPlayerOnDamaged(Player* Defender, PlayerHitResult result, std::unordered_map<int, Player*>& playerList)
+{
+      for (auto& [id, p] : playerList)
+    		{
+        	if (!p) continue;
+
+        	auto session = p->GetSession();
+        	if (!session) continue;
+
+        	std::vector<std::string> payload;
+        	payload.reserve(6);
+
+        	if (p == Defender)
+        	{
+        	    // 본인: 상세
+        	    payload.push_back(std::to_string(result.player_id));
+        	    payload.push_back(std::to_string(result.attacker_instance_id));
+        	    payload.push_back(std::to_string(result.damage));
+        	    payload.push_back(std::to_string(result.cur_hp));
+        	    payload.push_back(std::to_string(result.max_hp));
+        	    payload.push_back(std::to_string(static_cast<int>(result.state)));
+        	}
+        	else
+        	{
+        	    // 타인: 최소(HP 미공개)
+        	    payload.push_back(std::to_string(result.player_id));
+        	    payload.push_back(std::to_string(result.attacker_instance_id));
+        	    payload.push_back(std::to_string(result.damage));
+        	    payload.push_back(std::to_string(static_cast<int>(result.state)));
+        	}
+
+        	session->Send(PKT_PLAYER_ONDAMAGED, payload);
+    }	
+}

--- a/SERVER/src/CHANNEL/packet/UseItemPacket.cpp
+++ b/SERVER/src/CHANNEL/packet/UseItemPacket.cpp
@@ -1,3 +1,4 @@
+#include "PlayerHandler.h"
 #include "common.h"
 #include "PacketParser.h"
 #include "ChannelSession.h"
@@ -12,7 +13,7 @@
 bool TransferData(Str_UseItem& str_itemData, UseItem& itemData);
 
 
-void UseItemPacket(PacketContext * ctx)
+void PlayerHandler:: UseItemPacket(PacketContext * ctx)
 {
     ChannelSession *session = nullptr;
     ItemService* item_service = nullptr;
@@ -79,7 +80,7 @@ void UseItemPacket(PacketContext * ctx)
     ))
     {
         rc = EXIT_FAILURE;
-        K_slog_trace(K_SLOG_ERROR, "[%s : %s][%d] ParseLengthPrefixedString fail", __FILE__, __FUNCTION__, __LINE__);
+        K_slog_trace(K_SLOG_ERROR, "[%s : %s : %d] ParseLengthPrefixedString fail", __FILE__, __FUNCTION__, __LINE__);
         goto err;
     }
 
@@ -94,7 +95,7 @@ void UseItemPacket(PacketContext * ctx)
     ))
     {
         rc = EXIT_FAILURE;
-        K_slog_trace(K_SLOG_ERROR, "[%s : %s][%d] ParseLengthPrefixedString fail", __FILE__, __FUNCTION__, __LINE__);
+        K_slog_trace(K_SLOG_ERROR, "[%s : %s : %d] ParseLengthPrefixedString fail", __FILE__, __FUNCTION__, __LINE__);
         goto err;
     }
 

--- a/SERVER/src/COMMON/packet/PacketParser.cpp
+++ b/SERVER/src/COMMON/packet/PacketParser.cpp
@@ -32,8 +32,8 @@ std::optional<ParsedPacket> PacketParser::Parse(std::vector<char>& buf)
     parsedPacket.type = type;
     parsedPacket.payload = std::string(payload, payloadLen);
 
-    K_slog_trace(K_SLOG_TRACE, "[%s] type=%x", __FUNCTION__, type);
-    K_slog_trace(K_SLOG_TRACE, "[%s][%d] payload[%d]", __FUNCTION__, __LINE__, payloadLen);
+    //K_slog_trace(K_SLOG_TRACE, "[%s] type=%x", __FUNCTION__, type);
+    //K_slog_trace(K_SLOG_TRACE, "[%s][%d] payload[%d]", __FUNCTION__, __LINE__, payloadLen);
     // for (int i = 0; i < payloadLen; i++)
     // {
     //     K_slog_trace(K_SLOG_TRACE, "[%x]", payload[i]);


### PR DESCRIPTION
작업 내용 :

1. CombatService 클래스 : ComputeHitMonsters 함수에서 std::vector<Monster> monsters로 받고 있어 몬스터들이 복사되어 체력이 변경되지 않는 문제가 발생 또한 HandleAttack 함수에서  std::vector<Monster> monster_list = map->GetMonsterList(); 여기도 복사로 받고 있어 몬스터의 체력이 변경되지 않고 있음을 발견

                          다들 &를 붙여 참조로 받아 몬스터 원본을 직접적으로 변경하는 방식으로 변경

2. MapInstance의 Broadcast 책임을 PacketSender 클래스로 분리 : - ItemPacketSender, PlayerPacketSender, MonsterPacketSender로 패킷 전송 책임 이동 - 기존 Broadcast 함수 제거

3. PlayerHandler의 패킷 처리 함수를 전역 함수에서 멤버 함수로 변경 : - MovePacket, AttackPacket, BasicAttackPacket, OnDamagedPacket, UseItemPacket 처리 로직 정리

4. Skill_Info 구조 개선 : - 기존 type enum을 cast type과 category enum class로 분리 - 기본 공격 판별을 위해 category를 추가하고 JSON 스키마도 함께 수정

5. Weapon_Info.h :  - 착용 무기 타입에 따라 기본 공격 스킬 정보를 조회할 수 있도록 WeaponType enum class 추가

<!--
    PR 제목 형식
    :sparkles: [Feature] 제목
    :hammer: [Refactoring] 제목
    :bug: [Fix] 제목
 -->

 ## 📌 개요 <!-- PR 내용에 대해 축약해서 적어주세요. -->
  -

 ## 💻 작업사항 <!-- PR 내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  -

 ## 💡 이슈 번호 <!-- 관련된 이슈 번호를 적어주세요 (ex. "- close #4242") -->
  -
