### PR TITLE
feat: redis활용하여 channel상태 공유 기능 추가

### DIFF
--- a/SERVER/include/COMMON/RedisCommonEnum.h
+++ b/SERVER/include/COMMON/RedisCommonEnum.h
@@ -1,0 +1,15 @@
+namespace ChannelState
+{
+    inline constexpr const char* NORMAL = "Normal";
+    inline constexpr const char* BUSY = "Busy";
+    inline constexpr const char* FULL = "Full";
+    inline constexpr const char* DIE = "Die";
+}
+
+enum class E_ChannelState
+{
+    Normal = 0,
+    Busy,
+    Full,
+    Die
+};

--- a/SERVER/src/CHANNEL/app/ChannelServer.cpp
+++ b/SERVER/src/CHANNEL/app/ChannelServer.cpp
@@ -1,12 +1,16 @@
 #include "ChannelServer.h"
 #include "common.h"
 #include "thread"
-
+#include "RedisClient.h"
+#include "RedisUtility.h"
+#include "ChannelStateUpdateTask.h"
+#include "RedisCommonEnum.h"
 
 #define THREAD_POOL_COUNT 4
+#define MAX_USER_COUNT 1000
 
 
-ChannelServer::ChannelServer() : m_channel_id(0), m_listen_fd(0), m_epfd(0), m_running(false), m_map_manager(this), m_map_service(m_player_mamager, m_map_manager), m_pool(THREAD_POOL_COUNT)
+ChannelServer::ChannelServer(const int channelId) : m_channel_id(channelId), m_listen_fd(0), m_epfd(0), m_running(false), m_map_manager(this), m_map_service(m_player_mamager, m_map_manager), m_pool(THREAD_POOL_COUNT), m_current_user_count(0), m_max_user_count(MAX_USER_COUNT)
 {
     m_item_manager = ItemManager::GetInstance();
     m_monster_manager = MonsterManager::GetInstance();
@@ -65,6 +69,10 @@ bool ChannelServer::Init(const int port)
    
    //맵매니저 스레드 시작
    m_map_manager.Start();
+
+   //채널 상태 업데이트 스레드 시작
+    std::thread stateUpdateThread(&ChannelServer::UpdateChannelState, this, 3, 10); // 3초마다 업데이트, TTL은 10초
+    stateUpdateThread.detach(); // 스레드를 분리하여 백그라운드에서 실행
 
    return true;
 }
@@ -259,8 +267,8 @@ void ChannelServer::OnAccept()
             inet_ntop(AF_INET, &caddr.sin_addr, ip, sizeof(ip));
             // 로그로 접속한 IP 정보 출력
         }
-
-
+        m_current_user_count++;
+        K_slog_trace(K_SLOG_TRACE, "[%s][%d] New Connection FD [%d] Current User Count [%d]\n", __FUNCTION__, __LINE__, cfd, m_current_user_count);
     }
 }
 
@@ -325,10 +333,71 @@ void ChannelServer::OnDisconnect(int fd)
 
     close(fd);
 
-    std::cout << "Disconnected FD [" << fd <<"]" << std::endl;
+    m_current_user_count--;
+    K_slog_trace(K_SLOG_TRACE, "[%s][%d] Disconnected FD [%d] Current User Count [%d]\n", __FUNCTION__, __LINE__, fd, m_current_user_count);
 }
 
 void ChannelServer::BroadCast()
 {
 
+}
+
+void ChannelServer::UpdateChannelState(const int interval, const int ttl)
+{
+    while(true)
+    {
+        auto task = std::make_unique<ChannelStateUpdateTask>(this, ttl);
+        this->GetThreadPool()->Submit(std::move(task));
+        sleep(interval); // 지정된 시간마다 업데이트
+    }
+}
+
+void ChannelServer::UpdateChannelStateToRedis(const int ttl)
+{
+    RedisClient* redis = RedisClient::GetInstance();
+    int curUser = m_current_user_count;
+    int maxUser = m_max_user_count;
+    std::string state;
+    int rc;
+
+    if (redis == nullptr)
+    {
+        K_slog_trace(K_SLOG_ERROR, "[%s][%d] RedisClient is nullptr", __FUNCTION__, __LINE__);
+        return;
+    }
+
+    int percentage = 0;
+    if (maxUser > 0)
+    {
+        percentage = (curUser * 100) / maxUser;
+    }
+    percentage = std::min(percentage, 100); // 최대 100%로 제한
+
+    if (percentage >= 90)
+    {
+        state = ChannelState::FULL;
+    }
+    else if (percentage >= 70)
+    {
+        state = ChannelState::BUSY;
+    }
+    else
+    {
+        state = ChannelState::NORMAL;
+    }
+
+    
+    std::map<std::string, std::string> redisMap;
+    redisMap["state"] = state;
+    redisMap["percentage"] = std::to_string(percentage);
+
+    rc = redis->HSetAll("channel:" + std::to_string(m_channel_id) + ":status", redisMap, ttl); // 지정된 시간 동안 유지
+    if (rc != 0)
+    {
+        K_slog_trace(K_SLOG_ERROR, "[%s][%d] Failed to update channel status to Redis", __FUNCTION__, __LINE__);
+        return;
+    }
+
+    K_slog_trace(K_SLOG_DEBUG, "[%s][%d] Updated channel status to Redis: state=%s, percentage=%d%%", __FUNCTION__, __LINE__, state.c_str(), percentage);
+    K_slog_trace(K_SLOG_DEBUG, "[%s][%d] Current User Count: %d, Max User Count: %d", __FUNCTION__, __LINE__, curUser, maxUser);
 }

--- a/SERVER/src/CHANNEL/app/ChannelServer.h
+++ b/SERVER/src/CHANNEL/app/ChannelServer.h
@@ -27,7 +27,7 @@
 class ChannelServer
 {
 public:
-    ChannelServer();
+    ChannelServer(const int channelId = 0);
     ~ChannelServer();
 
     bool Init(const int port);
@@ -44,6 +44,8 @@ public:
     CombatService* GetCombatService() {return &m_combat_service;}
     TradeService* GetTradeService() {return &m_trade_service;}
     ThreadPool* GetThreadPool() {return &m_pool;}
+    void UpdateChannelState(const int interval, const int ttl);
+    void UpdateChannelStateToRedis(const int ttl);
 private:
     bool InitListenSocket(int port);
     bool InitEpoll();
@@ -82,4 +84,7 @@ private:
     TradeService m_trade_service;
 
     LevelManager* m_level_manager;
+
+    unsigned int m_current_user_count;
+    unsigned int m_max_user_count;
 };

--- a/SERVER/src/CHANNEL/app/ChannelStateUpdateTask.h
+++ b/SERVER/src/CHANNEL/app/ChannelStateUpdateTask.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Task.h"
+#include "ChannelServer.h"
+
+class ChannelStateUpdateTask : public Task
+{
+public:
+    ChannelStateUpdateTask(ChannelServer* server, const int ttl) : m_server(server), m_ttl(ttl) {}
+    void Execute() override
+    {
+        if (m_server)
+            m_server->UpdateChannelStateToRedis(m_ttl);
+    }
+private:
+    ChannelServer* m_server;
+    const int m_ttl;
+};

--- a/SERVER/src/CHANNEL/main.cpp
+++ b/SERVER/src/CHANNEL/main.cpp
@@ -61,7 +61,7 @@ int main(int ac, char **av)
 
         g_config = loader.ToAppConfig();
         MySqlConnectionPool::GetInstance(g_config.mysql);
-        ChannelServer channelServer;
+        ChannelServer channelServer(channelIndex + 1); // 채널 인덱스는 1부터 시작
 
         bool start = channelServer.Init(g_config.channelServer.port + channelIndex);
         if (start == false)

--- a/SERVER/src/WORLD/app/ChannelManager.cpp
+++ b/SERVER/src/WORLD/app/ChannelManager.cpp
@@ -2,6 +2,7 @@
 #include "K_slog.h"
 #include "RedisClient.h"
 #include "MySqlConnectionPool.h"
+#include "RedisCommonEnum.h"
 
 ChannelManager::ChannelManager()
 {
@@ -128,4 +129,43 @@ ChannelInfo ChannelManager::SelectBestChannel()
 
 //err:
     return info;
+}
+
+int ChannelManager::CanEnterChannel(const std::string& channel_id)
+{
+    E_ChannelState result_state = E_ChannelState::Die;
+    RedisClient* redis = RedisClient::GetInstance();
+    if (redis == nullptr)
+    {
+        K_slog_trace(K_SLOG_ERROR, "[%s][%d] RedisClient is nullptr", __FUNCTION__, __LINE__);
+        return (int)E_ChannelState::Die;
+    }
+
+    auto redis_value = redis->HGetAll("channel:" + channel_id + ":status");
+    if (redis_value.has_value() && !redis_value->empty())
+    {
+        auto it = redis_value->find("state");
+        if (it != redis_value->end())
+        {
+            std::string state = it->second;
+            if (state == ChannelState::NORMAL)
+                result_state = E_ChannelState::Normal;
+            else if (state == ChannelState::BUSY)
+                result_state = E_ChannelState::Busy;
+            else if (state == ChannelState::FULL)
+                result_state = E_ChannelState::Full;
+            else 
+                result_state = E_ChannelState::Die;
+
+            K_slog_trace(K_SLOG_DEBUG, "[%s][%d] channel(%s) status from Redis: state=%s", __FUNCTION__, __LINE__, channel_id.c_str(), state.c_str());
+            K_slog_trace(K_SLOG_DEBUG, "[%s][%d] channel(%s) percentage from Redis: percentage=%s%%", __FUNCTION__, __LINE__, channel_id.c_str(), redis_value->find("percentage") != redis_value->end() ? redis_value->find("percentage")->second.c_str() : "N/A");
+        }
+    }
+    else
+    {
+        K_slog_trace(K_SLOG_ERROR, "[%s][%d] Failed to get channel status from Redis for channel(%s)", __FUNCTION__, __LINE__, channel_id.c_str());
+        return (int)E_ChannelState::Die;
+    }
+
+    return (int)result_state;
 }

--- a/SERVER/src/WORLD/app/ChannelManager.h
+++ b/SERVER/src/WORLD/app/ChannelManager.h
@@ -30,6 +30,7 @@ public:
     ChannelInfo* GetChannel(const std::string& id);
     int LoadFromRedis(RedisClient&);
     int SaveToRedis(RedisClient&);
+    int CanEnterChannel(const std::string& channel_id);
 private:
     //key=channel_id, value=ChannelInfo
     std::map<std::string, ChannelInfo> m_channels;

--- a/SERVER/src/WORLD/packet/ChannelSelectHandler.cpp
+++ b/SERVER/src/WORLD/packet/ChannelSelectHandler.cpp
@@ -70,9 +70,23 @@ err:
         else
         {
             ChannelInfo info = *opt;
+            int channel_state = (int)channel_manager->CanEnterChannel(channel_id);
+            // switch (channel_state)
+            // {
+            // case ChannelState::E_Normal: //정상
+            //     break;
+            // case ChannelState::E_Busy: //혼잡
+            //     break;
+            // case ChannelState::E_Full:  //만원
+            //     break;
+            // case ChannelState::E_Die:   //죽음
+            //     break;
+            // }
+
             std::vector<std::string> channel_info;
             channel_info.push_back(info.ip);
             channel_info.push_back(std::to_string(info.port));
+            channel_info.push_back(std::to_string(channel_state)); //상태에 따른 클라이언트 처리 가능
             session->SendOk(PKT_SELECT_CHANNEL, channel_info);
         }
     }


### PR DESCRIPTION
[common]
1. RedisCommonEnum.h 추가
 - 채널 상태를 나타내는 E_ChannelState 열거형 정의, ChannelState 문자열 상수 정의 [channel]
1. ChannelServer.cpp::Init에서 UpdateChannelState를 스레드로 실행
 - UpdateChannelState에서 3초간격으로 스레드풀활용하여 UpdateChannelStateToRedis 실행
 - UpdateChannelStateToRedis: 현재 접속한 이용자수를 계산하여 channel:{channel_id}:state에 상태와 백분율 저장
2. m_current_user_count(현재 채널에 접속한 이용자수)
 - OnAccept에서 증가, OnDisconnect에서 감소 [world]
1. ChannelSelectHandler.cpp::HandleChannelSelect에서 ChannelManager::CanEnterChannel 호출하여 채널 상태 확인 후 클라이언트에 상태값 전송 (클라에서 상태값 판단하여 접속 허용 처리)
2. ChannelManager.cpp::CanEnterChannel에서 RedisClient 활용하여 channel:{channel_id}:state에서 상태값 조회하여 반환

<!--
    PR 제목 형식
    :sparkles: [Feature] 제목
    :hammer: [Refactoring] 제목
    :bug: [Fix] 제목
 -->

 ## 📌 개요 <!-- PR 내용에 대해 축약해서 적어주세요. -->
  -

 ## 💻 작업사항 <!-- PR 내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  -

 ## 💡 이슈 번호 <!-- 관련된 이슈 번호를 적어주세요 (ex. "- close #4242") -->
  -
