### PR TITLE
:bug: fix : 패킷사이즈 에러

### DIFF
--- a/SERVER/src/COMMON/packet/PacketParser.cpp
+++ b/SERVER/src/COMMON/packet/PacketParser.cpp
@@ -182,7 +182,7 @@ std::string PacketParser::MakeBody(const std::vector<std::string>& datas)
 std::string PacketParser::MakePacket(uint16_t type, const std::string &body)
 {
    const size_t maximumPacketSize = std::min(
-        static_cast<size_t>(BUFFER_SIZE),
+        static_cast<size_t>(14096),
         static_cast<size_t>(std::numeric_limits<uint16_t>::max())
     );
 


### PR DESCRIPTION
패킷 사이즈가 너무 작게 설정되어 있어 클라이언트 연결 실패 에러 발생
1024 -> 14096 사이즈로 임시 수정

<!--
    PR 제목 형식
    :sparkles: [Feature] 제목
    :hammer: [Refactoring] 제목
    :bug: [Fix] 제목
 -->

 ## 📌 개요 <!-- PR 내용에 대해 축약해서 적어주세요. -->
  -

 ## 💻 작업사항 <!-- PR 내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  -

 ## 💡 이슈 번호 <!-- 관련된 이슈 번호를 적어주세요 (ex. "- close #4242") -->
  -
